### PR TITLE
Update parsedown compatibility for 1.8.0

### DIFF
--- a/Service/Parsedown.php
+++ b/Service/Parsedown.php
@@ -8,11 +8,12 @@ class Parsedown extends \Parsedown
 {
     /**
      * @param array<string, mixed> $line
+     * @param array<string, mixed>|null $currentBlock
      * @return array<string, mixed>|null
      */
-    protected function blockList($line): ?array
+    protected function blockList($line, ?array $currentBlock = null): ?array
     {
-        $block = parent::blockList($line);
+        $block = parent::blockList($line, $currentBlock);
 
         if ($block === null) {
             return null;

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "symfony-bundle",
     "require": {
         "php": ">=8.1",
-        "erusev/parsedown": "^1.7",
+        "erusev/parsedown": "^1.8",
         "symfony/cache-contracts": "^2.0|^3.0",
         "symfony/config": "^5.4|^6.0|^7.0",
         "symfony/dependency-injection": "^5.4|^6.0|^7.0",


### PR DESCRIPTION
- Add $currentBlock parameter to blockList() to match updated Parsedown parent signature
- Bump erusev/parsedown requirement from ^1.7 to ^1.8